### PR TITLE
Fixed `FixedLenNTStr._from_bytes(...)` call returning `takewhile` strings instead of `str` strings

### DIFF
--- a/src/binary_file_parser/types/le/string.py
+++ b/src/binary_file_parser/types/le/string.py
@@ -101,7 +101,7 @@ class FixedLenNTStr(FixedLenStr):
 
     def _from_bytes(self, bytes_: bytes, *, struct_ver: Version = Version((0,))) -> str:
         value = super()._from_bytes(bytes_, struct_ver = struct_ver)
-        return str(takewhile(partial(ne, "\x00"), value))
+        return ''.join(takewhile(partial(ne, "\x00"), value))
 
 
 class StrArray(BaseStr):


### PR DESCRIPTION
There might be a better solution (?). This is the cleanest I could find through a short check. 

Let me know what you think 🙂 